### PR TITLE
use the alpine version to reduce image size

### DIFF
--- a/hello/Dockerfile
+++ b/hello/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:12-alpine
 RUN npm install
 COPY hello.js .
 EXPOSE 8080


### PR DESCRIPTION
By using the `node:12-alpine` instead of `node:12` we can reduce the container registry size significantly: `~350 MiB` -> `~30MiB`. This helps customers and testers as it does not eat that much container registry upload and pull quota  (e.g. ICR allows only 500MiB storage and 5GiB pull). Additionally, it improves the performance of app deployments.

see also 
https://hub.docker.com/_/node

I verified that the hello world application is still working as expected: 
![image](https://user-images.githubusercontent.com/36001299/92282753-9230d880-eefe-11ea-8dfd-d6712f4d7754.png)
