### PR TITLE
The binary / image can now act as application and job

### DIFF
--- a/helloworld/Dockerfile
+++ b/helloworld/Dockerfile
@@ -1,4 +1,80 @@
-FROM golang
-COPY helloworld.go /
-RUN go build -o /helloworld /helloworld.go
-CMD /helloworld
+# Copyright Contributors to the Code Engine Samples project
+
+FROM golang:buster as build
+
+# Silence frontend related debconf messages
+ENV DEBIAN_FRONTEND noninteractive
+
+# Switch to a Unicode locale
+ENV LANG C.UTF-8
+
+# Non-root user settings, use "random" uid > 10000
+ENV USER=runner
+ENV UID=17649
+
+    # Refresh package index files
+    # --assume-yes: Automatic yes to prompts
+    # --quiet: Logging but omit progress indicators
+RUN apt-get update --assume-yes --quiet && \
+    \
+    \
+    # Install required packages for build and runtime
+    # Runtime files will be copied to runtime image
+    apt-get install --assume-yes --quiet \
+      ca-certificates \
+      tzdata && \
+    \
+    \
+    # Add new user, created files will be copied to runtime image
+    # golang needs a home directory
+    # User has no password and cannot log in
+    # Login shell won't exist in target image
+    adduser \
+      --home "/${USER}" \
+      --shell "/usr/sbin/nologin" \
+      --uid "${UID}" \
+      --gecos "" \
+      --disabled-password \
+      "${USER}"
+
+# Use / as working directory
+WORKDIR /
+
+# Copy source from build context into container
+COPY helloworld.go .
+
+# Set target OS / architecture for golang, disable cgo
+ENV GOOS=linux
+ENV GOARCH=amd64
+ENV CGO_ENABLED=0
+
+# Build a static binary for target OS / architecture
+RUN go version && \
+    \
+    \
+    go build \
+      -a \
+      -ldflags='-extldflags "-static"' \
+      -o helloworld \
+      helloworld.go
+
+### Target image
+FROM scratch
+
+# Switch to target user... must be the same as specified with USER above
+USER runner:runner
+
+# Set the working directory... must be the same as specified with USER above
+WORKDIR /runner
+
+# Copy required files from build image to target image
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=build /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=build /etc/passwd /etc/passwd
+COPY --from=build /etc/group /etc/group
+
+# Copy static binary to run from build image to target image
+COPY --from=build /helloworld .
+
+# Run the binary
+ENTRYPOINT [ "./helloworld" ]

--- a/helloworld/README.md
+++ b/helloworld/README.md
@@ -1,7 +1,14 @@
 # HelloWorld
 
-A pretty simple golang application that, in its most basic form, will
+A pretty simple golang application / job that, in its most basic form, will
 return "Hello World" back to the caller.
+
+If environment variable `JOB_INDEX` is set, the binary will act as run-to-completion
+workload - it prints text to stdout and completes with exit code 0. So when using
+the image in a Code Engine Batch job, it will act accordingly.
+
+When using the image in a Code Engine Application, it will listen to requests and
+respond to them. It will keep running until stopped from outside.
 
 Check the source code for all of the things you can make it do either via
 environment variables or query parameters. This is good for testing the

--- a/helloworld/build
+++ b/helloworld/build
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Copyright Contributors to the Code Engine Samples project
+
 # Env Vars:
 # REPOSITORY: name of the image registry/namespace to store the images
 


### PR DESCRIPTION
The binary / image can now act as application and job. It uses the envrionment variable "JOB_INDEX" to determine whether it's an application or not.

Some more changes:
* Separate build image from runtime image.
* Runtime image bases on SCRATCH with minimum content - needs a static, self-contained binary.
* Runtime image is non-root.
* Add copyright headers.
* Update README.