### PR TITLE
Remove misleading main attribute from package.json

### DIFF
--- a/s2i-buildpacks/package.json
+++ b/s2i-buildpacks/package.json
@@ -5,7 +5,6 @@
   },
   "description": "Sample Node.js Application using NPM",
   "license": "Apache-2.0",
-  "main": "server.js",
   "name": "sample",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The `main` attribute in a package.json file has only meaning for a node module but not for an application. We should remove the attribute to prevent confusion when users think they need to simply change this attribute if they have no server.js.

Same will be done for the Paketo sample as discussed with their community, see [slack](https://paketobuildpacks.slack.com/archives/CUD6R3CPL/p1602776261010300).