### PR TITLE
Fix broken Kaniko build due to symlink

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:alpine
-COPY codeengine.go /
+COPY helloworld/helloworld.go /codeengine.go
 RUN go build -o /codeengine /codeengine.go
 
 # Copy the exe into a smaller base image

--- a/codeengine.go
+++ b/codeengine.go
@@ -1,1 +1,0 @@
-helloworld/helloworld.go


### PR DESCRIPTION
There are differences on how Docker builds the Dockerfile with a symlink and
how Kaniko operates on the same file. In contrast to Docker build, the COPY
command for Kaniko behaves more like a `cp -R from to` and therefore preserves
the symlink as a symlink. In Docker, during the build, the COPY resolves the
symlink to place it as a regular file from the build context into the layer.
This creates the problem, that a Dockerfile with a COPY statement against a
symlink is hard to maintain to be both supporting Docker builds and Kaniko.
With the current Dockerfile, a COPY command with Kaniko results in a broken
symlink, because it preserves it and after the copy the target path does not
exist due to the fact that it is a relative path in the repo.

Remove symlink from Git repo root.

Use symlink target `helloworld/helloworld.go` directly in root level Dockerfile.

Signed-off-by: Matthias Diester <matthias.diester@de.ibm.com>