### PR TITLE
Alternative approach to fix Kaniko build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM golang:alpine
+COPY ./helloworld /helloworld
 COPY codeengine.go /
 RUN go build -o /codeengine /codeengine.go
 


### PR DESCRIPTION
This preserves the existing symlink, but ensures that the
symlink target is present when copying the symlink, so that
Kaniko can properly execute the CP cmd.

Signed-off-by: Matthias Diester <matthias.diester@de.ibm.com>