### PR TITLE
remove manual lock/unlock in session sample

### DIFF
--- a/sessions/sessions.go
+++ b/sessions/sessions.go
@@ -20,34 +20,11 @@ func NewClient() *redis.Client {
 	})
 }
 
-func Lock() {
-	fmt.Printf("Waiting for lock\n")
-	for {
-		b, err := client.SetNX("lock", "lock", time.Second*10).Result()
-		fmt.Printf("b,err = %v, %v\n", b, err)
-		if b {
-			break
-		}
-		time.Sleep(time.Second)
-	}
-	fmt.Printf("Got it\n")
-}
-
-func Unlock() {
-	fmt.Printf("Unlocking\n")
-	client.Del("lock")
-	fmt.Printf("Unlocked\n")
-}
-
 func Handler(w http.ResponseWriter, r *http.Request) {
-	Lock()
-	count, err := client.Get("count").Int()
-	if err != nil && err.Error() != "redis: nil" {
+	count, err := client.Incr("count").Result()
+	if err != nil {
 		fmt.Fprintf(w, "Err: %v\n", err)
 	}
-	count = count + 1
-	client.Set("count", count, 0)
-	Unlock()
 
 	fmt.Fprintf(w, "Counter: %v  ", count)
 	fmt.Fprintf(w, "Hostname: %s\n", os.Getenv("HOSTNAME"))


### PR DESCRIPTION
Redis has ensured the locking under the hood, and hence we can use `client.Incr()` to simplify the client code.

Tested by accessing the endpoints in 2 terminals:

<img width="1647" alt="image" src="https://user-images.githubusercontent.com/1425903/119243822-268bab80-bb1f-11eb-9ea2-c26ecb6573fe.png">
