### PR TITLE
use same terminalogy in readme as UX

### DIFF
--- a/app2job/README.md
+++ b/app2job/README.md
@@ -1,9 +1,9 @@
 # App2Job
 
 This sample will show how to create a Batch Job from within an Application.
-It will first create an Application and then a Job definition. The Job will
-simply print a welcome message to its logs. The Job will be defined to run
-50 instances.
+It will first create an Application and then a Job. The Job will simply
+print a welcome message to its logs. The Job will be defined to run 50
+instances.
 
 The Application will wait for an HTTP PUT request containing the name of the
 Job definition in its HTTP Path. It will then use that Job definition name


### PR DESCRIPTION
changed "job definition" to job to use the same terminology in the readme as the UX uses.