### PR TITLE
Bugfix/Fixed broken docker build

### DIFF
--- a/hello/Dockerfile
+++ b/hello/Dockerfile
@@ -1,5 +1,6 @@
 FROM icr.io/codeengine/node:18-alpine
-RUN npm install
+WORKDIR /app
+RUN npm init -f && npm install
 COPY server.js .
 EXPOSE 8080
 CMD [ "node", "server.js" ]

--- a/hello/Dockerfile
+++ b/hello/Dockerfile
@@ -1,4 +1,4 @@
-FROM icr.io/codeengine/node:18-alpine
+FROM icr.io/codeengine/node:20-alpine
 WORKDIR /app
 RUN npm init -f && npm install
 COPY server.js .


### PR DESCRIPTION
This PR fixes the error message one got on: `ibmcloud ce app create -n hello --src . `
```
#6 [2/3] RUN npm install
#6 1.741 npm ERR! Tracker "idealTree" already exists
#6 1.744 
#6 1.744 npm ERR! A complete log of this run can be found in: /root/.npm/_logs/2023-11-15T13_12_05_887Z-debug-0.log
#6 ERROR: process "/bin/sh -c npm install" did not complete successfully: exit code: 1
------
 > [2/3] RUN npm install:
1.741 npm ERR! Tracker "idealTree" already exists
1.744 
1.744 npm ERR! A complete log of this run can be found in: /root/.npm/_logs/2023-11-15T13_12_05_887Z-debug-0.log
------
Dockerfile:2
--------------------
   1 |     FROM icr.io/codeengine/node:18-alpine
   2 | >>> RUN npm install
   3 |     COPY server.js .
   4 |     EXPOSE 8080
--------------------
error: failed to solve: process "/bin/sh -c npm install" did not complete successfully: exit code: 1
```