### PR TITLE
Allow user to configure separate names for ce and sm secrets

### DIFF
--- a/app-n-event-notification/README.md
+++ b/app-n-event-notification/README.md
@@ -30,7 +30,7 @@ These are the steps which we will follow:
 ## Instructions to use:
 - Install Code Engine cli \
   Command: `ibmcloud plugin install code-engine`
-- Install Event Notifications cli \
+- Install Event Notifications cli, version 1.0.1 or later\
   Command: `ibmcloud plugin install event-notifications`
 - Install the Secrets Manager CLI \
   Command: `ibmcloud plugin install secrets-manager`

--- a/app-n-event-notification/README.md
+++ b/app-n-event-notification/README.md
@@ -30,8 +30,8 @@ These are the steps which we will follow:
 ## Instructions to use:
 - Install Code Engine cli \
   Command: `ibmcloud plugin install code-engine`
-- Install Event Notifications cli, version 0.2.0 or later\
-  Command: `ibmcloud plugin install en@0.2.0`
+- Install Event Notifications cli \
+  Command: `ibmcloud plugin install event-notifications`
 - Install the Secrets Manager CLI \
   Command: `ibmcloud plugin install secrets-manager`
 - Login to your IBM Cloud Account and select the region and resource group \

--- a/app-n-event-notification/main.go
+++ b/app-n-event-notification/main.go
@@ -99,10 +99,9 @@ func CreateService() *Service {
 }
 
 func NewCodeEngineService(authenticator *core.IamAuthenticator) *ce.CodeEngineV2 {
-	region := os.Getenv("CE_REGION")
 	codeEngineService, err := ce.NewCodeEngineV2(&ce.CodeEngineV2Options{
 		Authenticator: authenticator,
-		URL:           "https://api." + region + ".codeengine.cloud.ibm.com/v2",
+		URL:           os.Getenv("CE_API_BASE_URL") + "/v2",
 	})
 	if err != nil {
 		log.Printf("NewCodeEngineV2 error: %v\n", err.Error())
@@ -161,11 +160,12 @@ func (svc *Service) GetSecretFromSM(id string) (*sm.ImportedCertificate, *core.D
 }
 
 func (svc *Service) UpdateSecretInCluster(secret *sm.ImportedCertificate) (*core.DetailedResponse, error) {
+	ce_secret := os.Getenv("CE_SECRET")
 	log.Println("Updating secret", *secret.Name)
 	projectID := os.Getenv("CE_PROJECT_ID")
 	replaceSecretOptions := &ce.ReplaceSecretOptions{
 		ProjectID: core.StringPtr(projectID),
-		Name:      core.StringPtr(*secret.Name),
+		Name:      &ce_secret,
 		IfMatch:   core.StringPtr("*"),
 		Format:    core.StringPtr("tls"),
 		Data: &ce.SecretDataTLSSecretData{


### PR DESCRIPTION
Changes in this PR : 
- use separate names for ce and sm secrets
- change event notification cli commands according to the latest version
- change event notification cli version to latest in README