### PR TITLE
Add GOTOOLCHAIN

### DIFF
--- a/metrics-collector/Dockerfile
+++ b/metrics-collector/Dockerfile
@@ -1,5 +1,7 @@
 FROM icr.io/codeengine/golang:alpine
 
+ENV GOTOOLCHAIN auto
+
 COPY . /
 RUN  go build -o /main /main.go
 


### PR DESCRIPTION
So that go 1.21 envs can safely build. The problem is that the base image in the Dockerfile is probably build with a go v1.21. When building, the go modules indicate that the required version is v1.22.

Adding the GOTOOLCHAIN to auto, to allow go to determine the right version so it can compile.