### PR TITLE
Image currency updates

### DIFF
--- a/gallery/app/Dockerfile
+++ b/gallery/app/Dockerfile
@@ -1,4 +1,5 @@
-FROM icr.io/codeengine/node:18-alpine
+FROM icr.io/codeengine/node:22-alpine
+RUN apk -U upgrade
 
 # Define which files should be copied into the container image
 COPY *.js .

--- a/gallery/build
+++ b/gallery/build
@@ -14,12 +14,12 @@ export REGISTRY=${REGISTRY:-icr.io/codeengine}
 
 # First build and push the app - notice no tag on the image name
 cd app
-podman build ${NOCACHE} -t ${REGISTRY}/gallery . --platform linux/amd64
-podman push ${REGISTRY}/gallery:latest
+docker build ${NOCACHE} -t ${REGISTRY}/gallery . --platform linux/amd64
+docker push ${REGISTRY}/gallery:latest
 cd ..
 
 # Second build and push the job - notice no tag on the image name
 cd job
-podman build ${NOCACHE} -t ${REGISTRY}/gallery-job . --platform linux/amd64
-podman push ${REGISTRY}/gallery-job:latest
+docker build ${NOCACHE} -t ${REGISTRY}/gallery-job . --platform linux/amd64
+docker push ${REGISTRY}/gallery-job:latest
 cd ..

--- a/gallery/job/Dockerfile
+++ b/gallery/job/Dockerfile
@@ -1,4 +1,5 @@
-FROM icr.io/codeengine/node:18-alpine
+FROM icr.io/codeengine/node:22-alpine
+RUN apk -U upgrade
 
 # Define which files should be copied into the container image
 COPY *.js .

--- a/hello/Dockerfile
+++ b/hello/Dockerfile
@@ -1,4 +1,5 @@
-FROM icr.io/codeengine/node:20-alpine
+FROM icr.io/codeengine/node:22-alpine
+RUN apk -U upgrade
 WORKDIR /app
 RUN npm init -f && npm install
 COPY server.js .

--- a/helloworld/Dockerfile
+++ b/helloworld/Dockerfile
@@ -1,8 +1,10 @@
 FROM icr.io/codeengine/golang:alpine
+RUN apk -U upgrade
 COPY helloworld.go /
 RUN go build -ldflags '-s -w -extldflags "-static"' -o /helloworld /helloworld.go
 
 # Copy the exe into a smaller base image
 FROM icr.io/codeengine/alpine
+RUN apk -U upgrade
 COPY --from=0 /helloworld /helloworld
 CMD /helloworld


### PR DESCRIPTION
This PR updates the node base image to use `node:22-alpine`

Furthermore, it adds update `apk -U upgrade` operations to the `hello`, `helloworld`, `gallery` Dockerfiles to make sure that the build images are picking up latest fixes.