### PR TITLE
Fix deprecated usage of `go get -d`

### DIFF
--- a/sessions/Dockerfile
+++ b/sessions/Dockerfile
@@ -1,6 +1,5 @@
 FROM icr.io/codeengine/golang
-COPY sessions.go /go/src/
 WORKDIR /go/src/
-RUN go mod init main && go mod tidy && go get -d .
+COPY . .
 RUN go build -o /sessions /go/src/sessions.go
-CMD /sessions
+CMD ["/sessions"]

--- a/thumbnail/eventer/Dockerfile
+++ b/thumbnail/eventer/Dockerfile
@@ -1,12 +1,9 @@
-FROM icr.io/codeengine/golang:alpine
-COPY eventer.go /go/src/
+FROM icr.io/codeengine/golang:alpine AS bootstrap
 WORKDIR /go/src/
-ENV GO111MODULE=off
-RUN apk update && apk add git
-RUN go get -d .
+COPY . .
 RUN go build -o /eventer eventer.go
 
 # Copy the exe into a smaller base image
 FROM icr.io/codeengine/alpine
-COPY --from=0 /eventer /eventer
-CMD /eventer
+COPY --from=bootstrap /eventer /eventer
+CMD ["/eventer"]

--- a/thumbnail/eventer/go.mod
+++ b/thumbnail/eventer/go.mod
@@ -1,0 +1,8 @@
+module github.com/IBM/CodeEngine/thumbnail/eventer
+
+go 1.16
+
+require (
+	github.com/duglin/cosclient v0.0.0-20220220144541-831ae437b3cd
+	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
+)

--- a/thumbnail/eventer/go.sum
+++ b/thumbnail/eventer/go.sum
@@ -1,0 +1,4 @@
+github.com/duglin/cosclient v0.0.0-20220220144541-831ae437b3cd h1:lO7UmDSOerJICyL9eSfGnHU1pBEhZl6+F5HCsiaTLLs=
+github.com/duglin/cosclient v0.0.0-20220220144541-831ae437b3cd/go.mod h1:aKXy6OcrgD6BYgZiuZt4NpCx/n5iFCjN8Kb5DvVxT74=
+github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
+github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=

--- a/thumbnail/v1/Dockerfile
+++ b/thumbnail/v1/Dockerfile
@@ -1,14 +1,11 @@
-FROM icr.io/codeengine/golang:alpine
-COPY app.go /go/src/
+FROM icr.io/codeengine/golang:alpine AS bootstrap
 WORKDIR /go/src/
-ENV GO111MODULE=off
-RUN apk update && apk add git
-RUN go get -d .
+COPY . .
 RUN go build -o /thumbnail app.go
 
 # Copy the exe into a smaller base image
 FROM icr.io/codeengine/alpine
-COPY --from=0 /thumbnail /thumbnail
+COPY --from=bootstrap /thumbnail /thumbnail
 COPY page.html /
 COPY pictures/* /pictures/
-CMD /thumbnail
+CMD ["/thumbnail"]

--- a/thumbnail/v1/go.mod
+++ b/thumbnail/v1/go.mod
@@ -1,0 +1,5 @@
+module github.com/IBM/CodeEngine/thumbnail/vOne
+
+go 1.16
+
+require github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646

--- a/thumbnail/v1/go.sum
+++ b/thumbnail/v1/go.sum
@@ -1,0 +1,2 @@
+github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
+github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=

--- a/thumbnail/v2/Dockerfile.app
+++ b/thumbnail/v2/Dockerfile.app
@@ -1,13 +1,11 @@
-FROM icr.io/codeengine/golang
-COPY app.go /go/src/
+FROM icr.io/codeengine/golang AS bootstrap
 WORKDIR /go/src/
-ENV GO111MODULE=off
-RUN go get -d .
+COPY . .
 RUN go build -o /app app.go
 
 # Copy the exe into a smaller base image
 FROM icr.io/codeengine/ubuntu
-COPY --from=0 /app /app
+COPY --from=bootstrap /app /app
 COPY page.html /
 COPY pictures/* /pictures/
-CMD /app
+CMD ["/app"]

--- a/thumbnail/v2/Dockerfile.job
+++ b/thumbnail/v2/Dockerfile.job
@@ -1,11 +1,9 @@
-FROM icr.io/codeengine/golang
-COPY job.go /go/src/
+FROM icr.io/codeengine/golang AS bootstrap
 WORKDIR /go/src/
-ENV GO111MODULE=off
-RUN go get -d .
+COPY . .
 RUN go build -o /job job.go
 
 # Copy the exe into a smaller base image
 FROM icr.io/codeengine/ubuntu
-COPY --from=0 /job /job
-CMD /job
+COPY --from=bootstrap /job /job
+CMD ["/job"]

--- a/thumbnail/v2/go.mod
+++ b/thumbnail/v2/go.mod
@@ -1,0 +1,8 @@
+module github.com/IBM/CodeEngine/thumbnail/vTwo
+
+go 1.16
+
+require (
+	github.com/duglin/cosclient v0.0.0-20220220144541-831ae437b3cd
+	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
+)

--- a/thumbnail/v2/go.sum
+++ b/thumbnail/v2/go.sum
@@ -1,0 +1,4 @@
+github.com/duglin/cosclient v0.0.0-20220220144541-831ae437b3cd h1:lO7UmDSOerJICyL9eSfGnHU1pBEhZl6+F5HCsiaTLLs=
+github.com/duglin/cosclient v0.0.0-20220220144541-831ae437b3cd/go.mod h1:aKXy6OcrgD6BYgZiuZt4NpCx/n5iFCjN8Kb5DvVxT74=
+github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
+github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=


### PR DESCRIPTION
With newer version of Go, the `go get -d` is no longer supported and breaks the build.
