### PR TITLE
Metrics collector - Turn-off disk usage per default

### DIFF
--- a/metrics-collector/README.md
+++ b/metrics-collector/README.md
@@ -47,6 +47,12 @@ $ ibmcloud ce subscription cron create \
     --schedule '*/1 * * * *'
 ```
 
+## Configuration
+
+Per default the metrics collector collects memory and CPU statistics, like `usage`, `current` and `configured`. 
+
+One can use the environment variable `COLLECT_DISKUSAGE=true` to also collect the amount of disk space that is used. Please note, the metrics collector can only calculate the overall file size stored in the pods filesystem which includes files that are part of the container image, the ephermal storage as well as mounted COS buckets. Hence, this metric cannot be used to calculate the ephemeral storage usage. 
+
 ## IBM Cloud Logs setup
 
 Once your IBM Cloud Code Engine project has detected a corresponding IBM Cloud Logs instance, which is configured to receive platform logs, you can consume the resource metrics in IBM Cloud Logs. Use the filter `metric:instance-resources` to filter for log lines that print resource metrics for each detected IBM Cloud Code Engine instance that is running in a project.
@@ -57,7 +63,7 @@ Along with a human readable message, like `Captured metrics of app instance 'loa
 
 E.g.
 - `cpu.usage:>80`: Filter for all log lines that noticed a CPU utilization of 80% or higher
-- `memory-current:>1000`: Filter for all log lines that noticed an instance that used 1GB or higher of memory
+- `memory.current:>1000`: Filter for all log lines that noticed an instance that used 1GB or higher of memory
 - `component_type:app`: Filter only for app instances. Possible values are `app`, `job`, and `build`
 - `component_name:<app-name>`: Filter for all instances of a specific app, job, or build
 - `name:<instance-name>`: Filter for a specific instance

--- a/metrics-collector/README.md
+++ b/metrics-collector/README.md
@@ -51,7 +51,7 @@ $ ibmcloud ce subscription cron create \
 
 Per default the metrics collector collects memory and CPU statistics, like `usage`, `current` and `configured`. 
 
-One can use the environment variable `COLLECT_DISKUSAGE=true` to also collect the amount of disk space that is used. Please note, the metrics collector can only calculate the overall file size stored in the pods filesystem which includes files that are part of the container image, the ephermal storage as well as mounted COS buckets. Hence, this metric cannot be used to calculate the ephemeral storage usage. 
+One can use the environment variable `COLLECT_DISKUSAGE=true` to also collect the amount of disk space that is used. Please note, the metrics collector can only calculate the overall file size stored in the pods filesystem which includes files that are part of the container image, the epheremal storage as well as mounted COS buckets. Hence, this metric cannot be used to calculate the ephemeral storage usage. 
 
 ## IBM Cloud Logs setup
 

--- a/metrics-collector/main.go
+++ b/metrics-collector/main.go
@@ -111,12 +111,10 @@ func collectInstanceMetrics() {
 
 	// fetches all pods
 	pods := getAllPods(coreClientset, namespace, config)
-	// fmt.Println("Captured pods after " + strconv.FormatInt(time.Since(startTime).Milliseconds(), 10) + "ms")
-
+	
 	// fetch all pod metrics
 	podMetrics := getAllPodMetrics(namespace, config)
-	// fmt.Println("Captured pod metrics after " + strconv.FormatInt(time.Since(startTime).Milliseconds(), 10) + "ms")
-
+	
 	var wg sync.WaitGroup
 
 	for _, metric := range *podMetrics {
@@ -124,8 +122,6 @@ func collectInstanceMetrics() {
 
 		go func(podMetric *v1beta1.PodMetrics) {
 			defer wg.Done()
-
-			// fmt.Println("Starting with pod of '" + podMetric.Name + "' ...")
 
 			// Determine the component type (either app, job, build or unknown)
 			componentType := determineComponentType(podMetric)
@@ -182,7 +178,6 @@ func collectInstanceMetrics() {
 
 				// determine the actual disk usage
 				storageCurrent := obtainDiskUsage(coreClientset, namespace, podMetric.Name, userContainerName, config)
-				// fmt.Println("Obtained disk usage of '" + podMetric.Name + "' after " + strconv.FormatInt(time.Since(startTime).Milliseconds(), 10) + " ms")
 				stats.DiskUsage.Current = int64(storageCurrent)
 
 				// extract memory and cpu limits
@@ -263,8 +258,7 @@ func getAllPods(coreClientset *kubernetes.Clientset, namespace string, config *r
 
 // Helper function to retrieve all pods from the Kube API
 func obtainDiskUsage(coreClientset *kubernetes.Clientset, namespace string, pod string, container string, config *rest.Config) float64 {
-	// fmt.Println("obtainDiskUsage > pod: '" + pod + "', container: '" + container + "'")
-
+	
 	// per default, we do not collect disk space statistics
 	if os.Getenv("COLLECT_DISKUSAGE") != "true" {
 		return 0
@@ -290,7 +284,6 @@ func obtainDiskUsage(coreClientset *kubernetes.Clientset, namespace string, pod 
 		option,
 		scheme.ParameterCodec,
 	)
-	// fmt.Println("obtainDiskUsage - URL: '" + req.URL().String() + "'")
 	exec, reqErr := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
 	if reqErr != nil {
 		fmt.Println("obtainDiskUsage of pod:" + pod + "/container:" + container + " failed POST err - " + reqErr.Error())
@@ -316,16 +309,13 @@ func obtainDiskUsage(coreClientset *kubernetes.Clientset, namespace string, pod 
 
 		return float64(0)
 	}
-	// fmt.Println("obtainDiskUsage of pod:" + pod + "/container:" + container + ": '" + diskUsageOutputStr + "'")
-
+	
 	// Parse the output "4000   /" by splitting the words
 	diskUsageOutput := strings.Fields(strings.TrimSuffix(diskUsageOutputStr, "\n"))
 	if len(diskUsageOutput) > 2 {
 		fmt.Println("obtainDiskUsage of pod:" + pod + "/container:" + container + " - len(diskUsageOutput): '" + strconv.Itoa(len(diskUsageOutput)) + "'")
 		return float64(0)
 	}
-
-	// fmt.Println("obtainDiskUsage of pod:" + pod + "/container:" + container + " - diskUsageOutput[0]: '" + diskUsageOutput[0] + "', len(diskUsageOutput): " + strconv.Itoa(len(diskUsageOutput)))
 
 	// Parse the integer string to a float64
 	ephemeralStorage, parseErr := strconv.ParseFloat(diskUsageOutput[0], 64)

--- a/metrics-collector/main.go
+++ b/metrics-collector/main.go
@@ -265,7 +265,8 @@ func getAllPods(coreClientset *kubernetes.Clientset, namespace string, config *r
 func obtainDiskUsage(coreClientset *kubernetes.Clientset, namespace string, pod string, container string, config *rest.Config) float64 {
 	// fmt.Println("obtainDiskUsage > pod: '" + pod + "', container: '" + container + "'")
 
-	if os.Getenv("SKIP_DISKUSAGE") == "true" {
+	// per default, we do not collect disk space statistics
+	if os.Getenv("COLLECT_DISKUSAGE") != "true" {
 		return 0
 	}
 

--- a/metrics-collector/main.go
+++ b/metrics-collector/main.go
@@ -111,17 +111,21 @@ func collectInstanceMetrics() {
 
 	// fetches all pods
 	pods := getAllPods(coreClientset, namespace, config)
+	// fmt.Println("Captured pods after " + strconv.FormatInt(time.Since(startTime).Milliseconds(), 10) + "ms")
 
 	// fetch all pod metrics
 	podMetrics := getAllPodMetrics(namespace, config)
+	// fmt.Println("Captured pod metrics after " + strconv.FormatInt(time.Since(startTime).Milliseconds(), 10) + "ms")
 
 	var wg sync.WaitGroup
 
-	for _, metric := range podMetrics {
+	for _, metric := range *podMetrics {
 		wg.Add(1)
 
-		go func(podMetric v1beta1.PodMetrics) {
+		go func(podMetric *v1beta1.PodMetrics) {
 			defer wg.Done()
+
+			// fmt.Println("Starting with pod of '" + podMetric.Name + "' ...")
 
 			// Determine the component type (either app, job, build or unknown)
 			componentType := determineComponentType(podMetric)
@@ -174,14 +178,15 @@ func collectInstanceMetrics() {
 			pod := getPod(podMetric.Name, pods)
 			if pod != nil {
 
-				userContainerName := getUserContainerName(componentType, *pod)
+				userContainerName := getUserContainerName(componentType, pod)
 
 				// determine the actual disk usage
 				storageCurrent := obtainDiskUsage(coreClientset, namespace, podMetric.Name, userContainerName, config)
+				// fmt.Println("Obtained disk usage of '" + podMetric.Name + "' after " + strconv.FormatInt(time.Since(startTime).Milliseconds(), 10) + " ms")
 				stats.DiskUsage.Current = int64(storageCurrent)
 
 				// extract memory and cpu limits
-				cpu, memory := getCpuAndMemoryLimits(userContainerName, *pod)
+				cpu, memory := getCpuAndMemoryLimits(userContainerName, pod)
 
 				cpuLimit := cpu.ToDec().AsApproximateFloat64() * 1000
 				stats.Cpu.Configured = int64(cpuLimit)
@@ -197,18 +202,18 @@ func collectInstanceMetrics() {
 
 			// Write the stringified JSON struct and make use of IBM Cloud Logs built-in parsing mechanism,
 			// which allows to annotate log lines by providing a JSON object instead of a simple string
-			fmt.Println(ToJSONString(stats))
+			fmt.Println(ToJSONString(&stats))
 
-		}(metric)
+		}(&metric)
 	}
 
 	wg.Wait()
 
-	fmt.Println("Captured pod metrics in " + strconv.FormatInt(time.Since(startTime).Milliseconds(), 10) + "ms")
+	fmt.Println("Captured pod metrics in " + strconv.FormatInt(time.Since(startTime).Milliseconds(), 10) + " ms")
 }
 
 // Helper function to determine the component type
-func determineComponentType(podMetric v1beta1.PodMetrics) ComponentType {
+func determineComponentType(podMetric *v1beta1.PodMetrics) ComponentType {
 	if _, ok := podMetric.ObjectMeta.Labels["buildrun.shipwright.io/name"]; ok {
 		return Build
 	}
@@ -222,8 +227,8 @@ func determineComponentType(podMetric v1beta1.PodMetrics) ComponentType {
 }
 
 // Helper function to obtain a pod by its name from a slice of pods
-func getPod(name string, pods []v1.Pod) *v1.Pod {
-	for _, pod := range pods {
+func getPod(name string, pods *[]v1.Pod) *v1.Pod {
+	for _, pod := range *pods {
 		if pod.Name == name {
 			return &pod
 		}
@@ -232,7 +237,7 @@ func getPod(name string, pods []v1.Pod) *v1.Pod {
 }
 
 // Helper function to retrieve all pods from the Kube API
-func getAllPods(coreClientset *kubernetes.Clientset, namespace string, config *rest.Config) []v1.Pod {
+func getAllPods(coreClientset *kubernetes.Clientset, namespace string, config *rest.Config) *[]v1.Pod {
 
 	// fetches all pods
 	pods := []v1.Pod{}
@@ -253,7 +258,7 @@ func getAllPods(coreClientset *kubernetes.Clientset, namespace string, config *r
 		}
 	}
 
-	return pods
+	return &pods
 }
 
 // Helper function to retrieve all pods from the Kube API
@@ -332,7 +337,7 @@ func obtainDiskUsage(coreClientset *kubernetes.Clientset, namespace string, pod 
 }
 
 // Helper function to retrieve all pod metrics from the Kube API
-func getAllPodMetrics(namespace string, config *rest.Config) []v1beta1.PodMetrics {
+func getAllPodMetrics(namespace string, config *rest.Config) *[]v1beta1.PodMetrics {
 	// obtain the metrics clientset
 	metricsclientset, err := metricsv.NewForConfig(config)
 	if err != nil {
@@ -358,11 +363,11 @@ func getAllPodMetrics(namespace string, config *rest.Config) []v1beta1.PodMetric
 		}
 	}
 
-	return podMetrics
+	return &podMetrics
 }
 
 // Helper function to obtain the name of the user container (that should be observed)
-func getUserContainerName(componentType ComponentType, pod v1.Pod) string {
+func getUserContainerName(componentType ComponentType, pod *v1.Pod) string {
 	if len(pod.Spec.Containers) == 0 {
 		return ""
 	}
@@ -380,7 +385,7 @@ func getUserContainerName(componentType ComponentType, pod v1.Pod) string {
 }
 
 // Helper function to extract CPU and Memory limits from the pod spec
-func getCpuAndMemoryLimits(containerName string, pod v1.Pod) (*resource.Quantity, *resource.Quantity) {
+func getCpuAndMemoryLimits(containerName string, pod *v1.Pod) (*resource.Quantity, *resource.Quantity) {
 
 	if len(containerName) == 0 {
 		return nil, nil
@@ -409,7 +414,7 @@ func ToJSONString(obj interface{}) string {
 		return ""
 	}
 
-	bytes, err := json.Marshal(&obj)
+	bytes, err := json.Marshal(obj)
 	if err != nil {
 		return "marshal error"
 	}


### PR DESCRIPTION
Calculating disk spaces does not work for any container image as it relies on the unix command `du -sm /`. Furthermore, it takes a considerable amount of time to calculate the pods disk usage, which has impact on performance in larger projects.

In consequence, this PR turns-off the collection of disk usage per default.

Users can use the environment variable `COLLECT_DISKUSAGE=true` to turn it on. 