### PR TITLE
replaces ENTRYPOINT for all node based runtime images

### DIFF
--- a/gallery/app/Dockerfile
+++ b/gallery/app/Dockerfile
@@ -15,4 +15,4 @@ FROM gcr.io/distroless/nodejs20-debian12
 COPY --from=build-env /app /app
 WORKDIR /app
 EXPOSE 8080
-ENTRYPOINT ["app.js"]
+CMD ["app.js"]

--- a/gallery/job/Dockerfile
+++ b/gallery/job/Dockerfile
@@ -12,4 +12,4 @@ RUN npm install
 FROM gcr.io/distroless/nodejs20-debian12
 COPY --from=build-env /app /app
 WORKDIR /app
-ENTRYPOINT ["job.js"]
+CMD ["job.js"]

--- a/hello/Dockerfile
+++ b/hello/Dockerfile
@@ -8,4 +8,4 @@ FROM gcr.io/distroless/nodejs20-debian12
 COPY --from=build-env /app /app
 WORKDIR /app
 EXPOSE 8080
-ENTRYPOINT ["server.js"]
+CMD ["server.js"]

--- a/satellite-connector-to-vpc-vsi/ce-job/Dockerfile
+++ b/satellite-connector-to-vpc-vsi/ce-job/Dockerfile
@@ -11,4 +11,4 @@ RUN npm install
 FROM gcr.io/distroless/nodejs20-debian12
 COPY --from=build-env /job /job
 WORKDIR /job
-ENTRYPOINT ["job.mjs"]
+CMD ["job.mjs"]


### PR DESCRIPTION
Replacing ENTRYPOINT definitions for all node-based distroless images
```
failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "server.js": executable file not found in $PATH: unknown
```