### PR TITLE
Also build nested directories in build-all

### DIFF
--- a/bin/build-all
+++ b/bin/build-all
@@ -7,20 +7,25 @@
 # will fail due to an auth failure. Which means, you also need to be logged
 # into that registry before you run it.
 
-cd $(dirname $0)/..
+set -euo pipefail
 
-set -e
-for file in */build ; do (
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
 
-  echo -e "\n### `dirname $file`\n"
-  cd `dirname $file`
+find "${REPO_DIR}" -maxdepth 3 -type f -executable -name build | while read -r buildFile; do
+  sampleDir="$(dirname "${buildFile}")"
+  echo
+  echo "### ${sampleDir}"
+  if [ -f "${sampleDir}/.SKIP" ]; then
+    echo "SKIPPING"
+    continue
+  fi
 
-  # Skip this dir
-  [[ -e .SKIP ]] && echo "SKIPPING `dirname $file`" && continue
+  pushd "${sampleDir}" >/dev/null
 
-  # Build the image(s)
   ./build
 
-) done
+  popd >/dev/null
+done
 
+echo
 echo "All done!"

--- a/trusted-profiles/README.md
+++ b/trusted-profiles/README.md
@@ -141,7 +141,7 @@ TRUSTED_PROFILE_NAME=code-engine-cos-access
 ibmcloud ce job create --name ${JOB_NAME} \
   --build-source https://github.com/IBM/CodeEngine \
   --build-context-dir trusted-profiles/${PROGRAMMING_LANGUAGE} \
-  --trusted-profiles-enabled true \
+  --trusted-profiles-enabled=true \
   --env COS_REGION=${REGION} \
   --env COS_BUCKET=${COS_BUCKET} \
   --env TRUSTED_PROFILE_NAME=${TRUSTED_PROFILE_NAME}


### PR DESCRIPTION
The trusted profile sample is nested because it contains one directory per language. The build file in those directories was not getting picked up.