### PR TITLE
Add Dockerfile for trusted-profiles/go sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.out
+.vscode
 node_modules

--- a/trusted-profiles/go/.dockerignore
+++ b/trusted-profiles/go/.dockerignore
@@ -1,0 +1,3 @@
+.dockerignore
+build
+Dockerfile

--- a/trusted-profiles/go/Dockerfile
+++ b/trusted-profiles/go/Dockerfile
@@ -1,0 +1,10 @@
+FROM quay.io/projectquay/golang:1.23 AS build-env
+WORKDIR /go/src/app
+COPY . .
+
+RUN CGO_ENABLED=0 go build -o /go/bin/app main.go
+
+# Copy the executable into a smaller base image
+FROM gcr.io/distroless/static-debian12
+COPY --from=build-env /go/bin/app /
+ENTRYPOINT ["/app"]


### PR DESCRIPTION
In the example, we build from source and point to the repo and context directory. In that case, the CLI cannot determine that this sample had no Dockerfile. Therefore adding one so that it is safe to run in all contexts.