### PR TITLE
Build with Go 1.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/projectquay/golang:1.22 AS build-env
+FROM quay.io/projectquay/golang:1.23 AS build-env
 WORKDIR /go/src/app
 COPY ./helloworld .
 COPY codeengine.go .

--- a/app2job/Dockerfile.app
+++ b/app2job/Dockerfile.app
@@ -1,4 +1,4 @@
-FROM quay.io/projectquay/golang:1.22 AS build-env
+FROM quay.io/projectquay/golang:1.23 AS build-env
 WORKDIR /go/src/app
 COPY app.go .
 

--- a/app2job/Dockerfile.job
+++ b/app2job/Dockerfile.job
@@ -1,4 +1,4 @@
-FROM quay.io/projectquay/golang:1.22 AS build-env
+FROM quay.io/projectquay/golang:1.23 AS build-env
 WORKDIR /go/src/app
 COPY job.go .
 

--- a/auth/Dockerfile.app
+++ b/auth/Dockerfile.app
@@ -1,4 +1,4 @@
-FROM quay.io/projectquay/golang:1.22 AS build-env
+FROM quay.io/projectquay/golang:1.23 AS build-env
 WORKDIR /go/src/app
 COPY . .
 

--- a/cecli/Dockerfile
+++ b/cecli/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/projectquay/golang:1.22 AS build-env
+FROM quay.io/projectquay/golang:1.23 AS build-env
 WORKDIR /go/src/app
 COPY . .
 

--- a/configmaps-env/Dockerfile
+++ b/configmaps-env/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/projectquay/golang:1.22 AS build-env
+FROM quay.io/projectquay/golang:1.23 AS build-env
 WORKDIR /go/src/app
 COPY config.go .
 

--- a/configmaps-vol/Dockerfile
+++ b/configmaps-vol/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/projectquay/golang:1.22 AS build-env
+FROM quay.io/projectquay/golang:1.23 AS build-env
 WORKDIR /go/src/app
 COPY config.go .
 

--- a/cos-event/Dockerfile
+++ b/cos-event/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/projectquay/golang:1.22 AS build-env
+FROM quay.io/projectquay/golang:1.23 AS build-env
 WORKDIR /go/src/app
 COPY cos-listen.go .
 

--- a/cron/Dockerfile
+++ b/cron/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/projectquay/golang:1.22 AS build-env
+FROM quay.io/projectquay/golang:1.23 AS build-env
 WORKDIR /go/src/app
 COPY cron.go .
 

--- a/cronjob/Dockerfile
+++ b/cronjob/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/projectquay/golang:1.22 AS build-env
+FROM quay.io/projectquay/golang:1.23 AS build-env
 WORKDIR /go/src/app
 COPY cronjob.go .
 RUN CGO_ENABLED=0 go build -o /go/bin/job cronjob.go

--- a/daemonjob/Dockerfile
+++ b/daemonjob/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/projectquay/golang:1.22 AS build-env
+FROM quay.io/projectquay/golang:1.23 AS build-env
 WORKDIR /go/src/app
 COPY daemonjob.go .
 RUN CGO_ENABLED=0 go build -o /go/bin/daemonjob daemonjob.go

--- a/function2job/Dockerfile
+++ b/function2job/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/projectquay/golang:1.22 AS build-env
+FROM quay.io/projectquay/golang:1.23 AS build-env
 WORKDIR /go/src/app
 COPY . .
 RUN CGO_ENABLED=0 go build -o /go/bin/job job.go

--- a/github/Dockerfile
+++ b/github/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/projectquay/golang:1.22 AS build-env
+FROM quay.io/projectquay/golang:1.23 AS build-env
 WORKDIR /go/src/app
 COPY github.go .
 

--- a/helloworld/Dockerfile
+++ b/helloworld/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/projectquay/golang:1.22 AS build-env
+FROM quay.io/projectquay/golang:1.23 AS build-env
 WORKDIR /go/src/app
 COPY . .
 

--- a/job2app/Dockerfile
+++ b/job2app/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/projectquay/golang:1.22 AS build-env
+FROM quay.io/projectquay/golang:1.23 AS build-env
 WORKDIR /go/src/app
 COPY job.go .
 

--- a/job2app/Dockerfile.app
+++ b/job2app/Dockerfile.app
@@ -1,4 +1,4 @@
-FROM quay.io/projectquay/golang:1.22 AS build-env
+FROM quay.io/projectquay/golang:1.23 AS build-env
 WORKDIR /go/src/app
 COPY app.go .
 

--- a/metrics-collector/Dockerfile
+++ b/metrics-collector/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/projectquay/golang:1.22 AS build-env
+FROM quay.io/projectquay/golang:1.23 AS build-env
 WORKDIR /go/src/app
 COPY . .
 

--- a/satellite-connector-to-vpc-vsi/ce-app/Dockerfile
+++ b/satellite-connector-to-vpc-vsi/ce-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/projectquay/golang:1.22 AS build-env
+FROM quay.io/projectquay/golang:1.23 AS build-env
 WORKDIR /go/src/app
 COPY . .
 

--- a/secrets-env/Dockerfile
+++ b/secrets-env/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/projectquay/golang:1.22 AS build-env
+FROM quay.io/projectquay/golang:1.23 AS build-env
 WORKDIR /go/src/app
 COPY . .
 

--- a/secrets-vol/Dockerfile
+++ b/secrets-vol/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/projectquay/golang:1.22 AS build-env
+FROM quay.io/projectquay/golang:1.23 AS build-env
 WORKDIR /go/src/app
 COPY . .
 

--- a/sessions/Dockerfile
+++ b/sessions/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/projectquay/golang:1.22 AS build-env
+FROM quay.io/projectquay/golang:1.23 AS build-env
 WORKDIR /go/src/app
 COPY . .
 

--- a/thumbnail/eventer/Dockerfile
+++ b/thumbnail/eventer/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/projectquay/golang:1.22 AS build-env
+FROM quay.io/projectquay/golang:1.23 AS build-env
 WORKDIR /go/src/app
 COPY . .
 

--- a/thumbnail/v1/Dockerfile
+++ b/thumbnail/v1/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/projectquay/golang:1.22 AS build-env
+FROM quay.io/projectquay/golang:1.23 AS build-env
 WORKDIR /go/src/app
 COPY . .
 

--- a/thumbnail/v2/Dockerfile.app
+++ b/thumbnail/v2/Dockerfile.app
@@ -1,4 +1,4 @@
-FROM quay.io/projectquay/golang:1.22 AS build-env
+FROM quay.io/projectquay/golang:1.23 AS build-env
 WORKDIR /go/src/app
 COPY . .
 

--- a/thumbnail/v2/Dockerfile.job
+++ b/thumbnail/v2/Dockerfile.job
@@ -1,4 +1,4 @@
-FROM quay.io/projectquay/golang:1.22 AS build-env
+FROM quay.io/projectquay/golang:1.23 AS build-env
 WORKDIR /go/src/app
 COPY . .
 

--- a/websocket/Dockerfile.client
+++ b/websocket/Dockerfile.client
@@ -1,4 +1,4 @@
-FROM quay.io/projectquay/golang:1.22 AS build-env
+FROM quay.io/projectquay/golang:1.23 AS build-env
 WORKDIR /go/src/app
 COPY client.go .
 

--- a/websocket/Dockerfile.server
+++ b/websocket/Dockerfile.server
@@ -1,4 +1,4 @@
-FROM quay.io/projectquay/golang:1.22 AS build-env
+FROM quay.io/projectquay/golang:1.23 AS build-env
 WORKDIR /go/src/app
 COPY server.go .
 


### PR DESCRIPTION
Go 1.22 is eol since February. Switching to Go 1.23.