### PR TITLE
add the retrieval of the  vsi-image-id by name regional 

### DIFF
--- a/experimental/serverless-fleets/init-fleet-sandbox
+++ b/experimental/serverless-fleets/init-fleet-sandbox
@@ -393,13 +393,16 @@ ibmcloud ce secret create --name fleet-registry-secret --format registry --serve
 
 # using the common base VSI image "jwe-ubuntu24-gpu" enabled for GPU and including podman and s3fs 
 print_msg "\nCreating a Code Engine configmap 'fleet-vpc-config' to access the new VPC ..."
+# retrieve the best fitting ubuntu vsi base image by selection from available image list 
+vsi-image-id=$(ic is images | grep ubuntu-24 | grep cloud_init | awk ' { print $1 }')
+print_msg "\nSelected the ubuntu-24 vsi image for fleets with the image-id = $vsi-image-id"
 ibmcloud ce configmap create --name fleet-vpc-config \
 --from-literal NETWORK_ZONE="${REGION}-1" \
 --from-literal SSH_SECRET_NAME="fleet-ssh-secret" \
 --from-literal VPC_ID="$(ibmcloud is vpc ${vpc_name} --output json | jq -r '.id')" \
 --from-literal SUBNET_ID="$(ibmcloud is subnet ${vpc_name}-subnet --output json | jq -r '.id')" \
 --from-literal SECURITY_GROUP_ID="$(ibmcloud is security-group ${vpc_name}-group --output json | jq -r '.id')" \
---from-literal VSI_IMAGE_ID="r010-e7b25759-7857-455a-aec0-904b65c3c4cb" \
+--from-literal VSI_IMAGE_ID="$vsi-image-id" \
 --from-literal VSI_PREFERRED_PROFILE="cx2-2x4"
 
 # alternative to fetch the latest stock image:

--- a/experimental/serverless-fleets/init-fleet-sandbox
+++ b/experimental/serverless-fleets/init-fleet-sandbox
@@ -158,7 +158,8 @@ target_resource_group $resource_group_name
 # Check whether Logging should be configured
 print_msg "\nShould IBM Cloud Logs be configured?"
 if [[ "$SETUP_LOGGING" != "true" ]]; then
-    echo "No!"
+    echo "No! Logging cannot be install afterwards to the VPC running your fleets"
+    sleep 2 
 else 
     echo "Yes!"
     print_msg "\nCreating the IBM Cloud Logs instance '$icl_name' ..."
@@ -195,7 +196,8 @@ fi
 # Check whether monitoring should be configured
 print_msg "\nShould IBM Cloud Monitoring be configured?"
 if [[ "$SETUP_MONITORING" != "true" ]]; then
-    echo "No!"
+    echo "No! Monitoring cannot be install afterwards to the VPC running your fleets""
+    sleep 2 
 else
     echo "Yes!"
     print_msg "\nCreating the IBM Cloud Monitoring instance '$sysdig_name' ..."

--- a/experimental/serverless-fleets/init-fleet-sandbox
+++ b/experimental/serverless-fleets/init-fleet-sandbox
@@ -124,6 +124,22 @@ print_msg "\n======================================================"
 print_msg " Setting up \"Code Engine Serverless Fleet\" sample"
 print_msg "======================================================\n"
 
+if [[ "$SETUP_LOGGING" != "true" || "$SETUP_MONITORING" != "true" ]]; then 
+   print_msg " ATTENTION: You requested to setup a fleet sandbox without : \n"
+   if [[ "$SETUP_LOGGING" != "true" ]]; then 
+        print_msg "  - logging support \n"
+   fi 
+   if [[ "$SETUP_MONITORING" != "true" ]]; then 
+        print_msg "  - monitoring support \n"
+   fi 
+   print_msg "Do you really want to continue setup without these services? They cannot be added later \n"
+   read -p "Continue [y|n]? " yn
+    case $yn in
+        [Yy]* ) ;;
+        * ) exit -1;;
+    esac 
+fi
+
 echo ""
 echo "Please note: This script will install various IBM Cloud resources within the resource group '$resource_group_name'."
 
@@ -158,8 +174,7 @@ target_resource_group $resource_group_name
 # Check whether Logging should be configured
 print_msg "\nShould IBM Cloud Logs be configured?"
 if [[ "$SETUP_LOGGING" != "true" ]]; then
-    echo "No! Logging cannot be install afterwards to the VPC running your fleets"
-    sleep 2 
+    echo "No! "
 else 
     echo "Yes!"
     print_msg "\nCreating the IBM Cloud Logs instance '$icl_name' ..."
@@ -196,8 +211,7 @@ fi
 # Check whether monitoring should be configured
 print_msg "\nShould IBM Cloud Monitoring be configured?"
 if [[ "$SETUP_MONITORING" != "true" ]]; then
-    echo "No! Monitoring cannot be install afterwards to the VPC running your fleets""
-    sleep 2 
+    echo "No!"
 else
     echo "Yes!"
     print_msg "\nCreating the IBM Cloud Monitoring instance '$sysdig_name' ..."
@@ -396,7 +410,7 @@ ibmcloud ce secret create --name fleet-registry-secret --format registry --serve
 # using the common base VSI image "jwe-ubuntu24-gpu" enabled for GPU and including podman and s3fs 
 print_msg "\nCreating a Code Engine configmap 'fleet-vpc-config' to access the new VPC ..."
 # retrieve the best fitting ubuntu vsi base image by selection from available image list 
-vsi-image-id=$(ic is images | grep ubuntu-24 | grep cloud_init | awk ' { print $1 }')
+vsi-image-id=$(ibmcloud is images --output JSON|jq -r 'first( .[]|select(.name | startswith("ibm-ubuntu-24")) ) | .id')
 print_msg "\nSelected the ubuntu-24 vsi image for fleets with the image-id = $vsi-image-id"
 ibmcloud ce configmap create --name fleet-vpc-config \
 --from-literal NETWORK_ZONE="${REGION}-1" \


### PR DESCRIPTION
The vsi base image  for fleets  ( the ubuntu-24-xxxxx)  has different image ids on  each IBM Cloud region. So it is necessyry to us the ibmcloud is images  command to get the image id in each region before the value can be written to the config-map  of the ce-project