### PR TITLE
add the limit to run the script only on valid regions

### DIFF
--- a/experimental/serverless-fleets/init-fleet-sandbox
+++ b/experimental/serverless-fleets/init-fleet-sandbox
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+#### Global vars 
+# vsi_images hashmap contains the list of valid vsi-images that can be used within fleets
+# The fleet sandbox can be setup on regions with a valid vsi-image, only. 
+declare -A vsi_images
+vsi_images["eu-de"]=r010-e7b25759-7857-455a-aec0-904b65c3c4cb 
+vsi_images["eu-gb"]=r018-31655c46-96e7-4d38-b61a-2ab1b66b9bbd 
+vsi_images["us-east"]=r014-b7f47448-72db-4012-b018-bb120518b078
+
 # Env vars
 CLEANUP_ON_ERROR=${CLEANUP_ON_ERROR:=false}
 CLEANUP_ON_SUCCESS=${CLEANUP_ON_SUCCESS:=false}
@@ -31,6 +39,13 @@ sysdig_key_name="${NAME_PREFIX}--sysdig-key"
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source ${SCRIPT_DIR}/common.sh
+
+
+
+
+
+
+
 
 # Clean up previous run
 function clean() {
@@ -145,6 +160,14 @@ echo "Please note: This script will install various IBM Cloud resources within t
 
 print_msg "\nChecking prerequisites ..."
 check_prerequisites
+
+# checking if a there is a valid vsi-image in the region available  
+vsi_image_id=${vsi_images[${REGION}]}
+
+if [[ $vsi_image_id == "" || $vsi_image_id == null ]]; then 
+   echo " Fleet sandbox setup is currently not supported in region ($region), exiting setup... "
+   exit -1
+fi
 
 # Ensure that latest versions of used IBM Cloud ClI is installed
 print_msg "\nPulling latest IBM Cloud CLI release ..."
@@ -409,8 +432,7 @@ ibmcloud ce secret create --name fleet-registry-secret --format registry --serve
 
 # using the common base VSI image "jwe-ubuntu24-gpu" enabled for GPU and including podman and s3fs 
 print_msg "\nCreating a Code Engine configmap 'fleet-vpc-config' to access the new VPC ..."
-# retrieve the best fitting ubuntu vsi base image by selection from available image list 
-vsi-image-id=$(ibmcloud is images --output JSON|jq -r 'first( .[]|select(.name | startswith("ibm-ubuntu-24")) ) | .id')
+
 print_msg "\nSelected the ubuntu-24 vsi image for fleets with the image-id = $vsi-image-id"
 ibmcloud ce configmap create --name fleet-vpc-config \
 --from-literal NETWORK_ZONE="${REGION}-1" \
@@ -418,7 +440,7 @@ ibmcloud ce configmap create --name fleet-vpc-config \
 --from-literal VPC_ID="$(ibmcloud is vpc ${vpc_name} --output json | jq -r '.id')" \
 --from-literal SUBNET_ID="$(ibmcloud is subnet ${vpc_name}-subnet --output json | jq -r '.id')" \
 --from-literal SECURITY_GROUP_ID="$(ibmcloud is security-group ${vpc_name}-group --output json | jq -r '.id')" \
---from-literal VSI_IMAGE_ID="$vsi-image-id" \
+--from-literal VSI_IMAGE_ID="$vsi_image_id" \
 --from-literal VSI_PREFERRED_PROFILE="cx2-2x4"
 
 # alternative to fetch the latest stock image:

--- a/experimental/serverless-fleets/init-fleet-sandbox
+++ b/experimental/serverless-fleets/init-fleet-sandbox
@@ -40,13 +40,6 @@ sysdig_key_name="${NAME_PREFIX}--sysdig-key"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source ${SCRIPT_DIR}/common.sh
 
-
-
-
-
-
-
-
 # Clean up previous run
 function clean() {
     (


### PR DESCRIPTION
The fleets can run only on specific vsi images that are only available in some regions. To control that the init-fleet-sandbox script well be executed only against regions where these vsi images exists a hashmap with the image_ids and the belonging regions are added. 
So the fleet sandbox can be setup on specific regions, only. 