### PR TITLE
fixed broken python docker build

### DIFF
--- a/trusted-profiles/python/Dockerfile
+++ b/trusted-profiles/python/Dockerfile
@@ -1,5 +1,5 @@
 # Download dependencies in builder stage
-FROM registry.access.redhat.com/ubi9/python-39 AS builder
+FROM registry.access.redhat.com/ubi9/python-312 AS builder
 
 COPY requirements.txt .
 RUN python -m pip install -r requirements.txt
@@ -9,7 +9,7 @@ FROM gcr.io/distroless/python3
 
 ENV PYTHONPATH=/app/site-packages
 
-COPY --chown=1001:0 --from=builder /opt/app-root/lib/python3.9/site-packages ${PYTHONPATH}
+COPY --chown=1001:0 --from=builder /opt/app-root/lib/python3.12/site-packages ${PYTHONPATH}
 COPY --chown=1001:0 main.py /app/
 
 USER 1001:0

--- a/trusted-profiles/python/requirements.txt
+++ b/trusted-profiles/python/requirements.txt
@@ -1,3 +1,3 @@
-ibm_cloud_sdk_core==3.23.0
-requests==2.33.0
-xmltodict==0.14.2
+ibm_cloud_sdk_core==3.24.4
+requests==2.33.1
+xmltodict==1.0.4


### PR DESCRIPTION
The IBM Core SDK dropped support for python 3.9. Hence docker builds failed with
```
#9 [builder 3/3] RUN python -m pip install -r requirements.txt
#9 0.964 Collecting ibm_cloud_sdk_core==3.23.0 (from -r requirements.txt (line 1))
#9 0.990   Downloading ibm_cloud_sdk_core-3.23.0-py3-none-any.whl.metadata (8.7 kB)
#9 1.031 ERROR: Ignored the following yanked versions: 2.32.0, 2.32.1
#9 1.032 ERROR: Ignored the following versions that require a different python version: 2.33.0 Requires-Python >=3.10; 2.33.1 Requires-Python >=3.10; 3.24.3 Requires-Python >=3.10; 3.24.4 Requires-Python >=3.10
#9 1.032 ERROR: Could not find a version that satisfies the requirement requests==2.33.0 (from versions: 0.2.0, 0.2.1, 0.2.2, 0.2.3, 0.2.4, 0.3.0, 0.3.1, 0.3.2, 0.3.3, 0.3.4, 0.4.0, 0.4.1, 0.5.0, 0.5.1, 0.6.0, 0.6.1, 0.6.2, 0.6.3, 0.6.4, 0.6.5, 0.6.6, 0.7.0, 0.7.1, 0.7.2, 0.7.3, 0.7.4, 0.7.5, 0.7.6, 0.8.0, 0.8.1, 0.8.2, 0.8.3, 0.8.4, 0.8.5, 0.8.6, 0.8.7, 0.8.8, 0.8.9, 0.9.0, 0.9.1, 0.9.2, 0.9.3, 0.10.0, 0.10.1, 0.10.2, 0.10.3, 0.10.4, 0.10.6, 0.10.7, 0.10.8, 0.11.1, 0.11.2, 0.12.0, 0.12.1, 0.13.0, 0.13.1, 0.13.2, 0.13.3, 0.13.4, 0.13.5, 0.13.6, 0.13.7, 0.13.8, 0.13.9, 0.14.0, 0.14.1, 0.14.2, 1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.1.0, 1.2.0, 1.2.1, 1.2.2, 1.2.3, 2.0.0, 2.0.1, 2.1.0, 2.2.0, 2.2.1, 2.3.0, 2.4.0, 2.4.1, 2.4.2, 2.4.3, 2.5.0, 2.5.1, 2.5.2, 2.5.3, 2.6.0, 2.6.1, 2.6.2, 2.7.0, 2.8.0, 2.8.1, 2.9.0, 2.9.1, 2.9.2, 2.10.0, 2.11.0, 2.11.1, 2.12.0, 2.12.1, 2.12.2, 2.12.3, 2.12.4, 2.12.5, 2.13.0, 2.14.0, 2.14.1, 2.14.2, 2.15.1, 2.16.0, 2.16.1, 2.16.2, 2.16.3, 2.16.4, 2.16.5, 2.17.0, 2.17.1, 2.17.2, 2.17.3, 2.18.0, 2.18.1, 2.18.2, 2.18.3, 2.18.4, 2.19.0, 2.19.1, 2.20.0, 2.20.1, 2.21.0, 2.22.0, 2.23.0, 2.24.0, 2.25.0, 2.25.1, 2.26.0, 2.27.0, 2.27.1, 2.28.0, 2.28.1, 2.28.2, 2.29.0, 2.30.0, 2.31.0, 2.32.2, 2.32.3, 2.32.4, 2.32.5)
#9 1.141 
```

This PR updates all dependencies to the latest greatest versions and upgrades to Python 3.12