### PR TITLE
[helloworld] apply random sleep per default

### DIFF
--- a/helloworld/helloworld.go
+++ b/helloworld/helloworld.go
@@ -310,9 +310,9 @@ func main() {
 		fleetName := os.Getenv("CE_FLEET_NAME")
 
 		sleep := os.Getenv("SLEEP")
-		sleepDuration := 0
-		if sleep == "RANDOM" {
-			sleepDuration = rand.IntN(SLEEP_MAX-SLEEP_MIN) + SLEEP_MIN
+		sleepDuration := rand.IntN(SLEEP_MAX-SLEEP_MIN) + SLEEP_MIN
+		if sleep == "NONE" {
+			sleepDuration = 0
 		} else {
 			sleepDuration, _ = strconv.Atoi(sleep)
 		}

--- a/helloworld/helloworld.go
+++ b/helloworld/helloworld.go
@@ -313,7 +313,7 @@ func main() {
 		sleepDuration := rand.IntN(SLEEP_MAX-SLEEP_MIN) + SLEEP_MIN
 		if sleep == "NONE" {
 			sleepDuration = 0
-		} else {
+		} else if len(sleep) > 0 {
 			sleepDuration, _ = strconv.Atoi(sleep)
 		}
 


### PR DESCRIPTION
In order to have a more realistic handling of fleet tasks, each task will a apply a random sleep per default. 

Note: This behaviour can be turned off by setting the env var `SLEEP=NONE`

This change is important for the upcoming DUX demo