### PR TITLE
TZ enablement - Resource group becomes a configurable parameter for setting up fleet envs

### DIFF
--- a/serverless-fleets/init-fleet-sandbox
+++ b/serverless-fleets/init-fleet-sandbox
@@ -20,7 +20,7 @@ IPS_PER_SUBNET=${IPS_PER_SUBNET:=1024}
 uuid=$(uuidgen | tr '[:upper:]' '[:lower:]' | awk -F- '{print $1}')
 
 # Dependent variables
-resource_group_name="${NAME_PREFIX}--rg"
+resource_group_name=${RESOURCE_GROUP:="${NAME_PREFIX}--rg"}
 ce_project_name="${NAME_PREFIX}--ce-project"
 vpc_name="${NAME_PREFIX}--is-vpc"
 sshkey_name="${NAME_PREFIX}--sshkey"

--- a/serverless-fleets/login
+++ b/serverless-fleets/login
@@ -1,8 +1,9 @@
 #!/bin/sh
 REGION="${REGION:=eu-de}"
 NAME_PREFIX="${NAME_PREFIX:=ce-fleet-sandbox}"
+RESOURCE_GROUP="${RESOURCE_GROUP:=$NAME_PREFIX--rg}"
 
-ibmcloud login --sso -r "$REGION" -g "${NAME_PREFIX}--rg"
+ibmcloud login --sso -r "$REGION" -g "$RESOURCE_GROUP"
 
 
 ibmcloud ce project select --name "${NAME_PREFIX}--ce-project"

--- a/serverless-fleets/upload
+++ b/serverless-fleets/upload
@@ -1,8 +1,9 @@
 #!/bin/sh
 
+NAME_PREFIX="${NAME_PREFIX:=ce-fleet-sandbox}"
 # get the current resource group name
 resource_group_name=$(ibmcloud target -o JSON | jq -r '.resource_group.name')
-cos_instance=${resource_group_name/--rg/}--cos
+cos_instance=${NAME_PREFIX}--cos
 
 echo "switching to COS instance $cos_instance"
 

--- a/serverless-fleets/watch_results
+++ b/serverless-fleets/watch_results
@@ -1,9 +1,10 @@
 #!/bin/sh
 
+NAME_PREFIX="${NAME_PREFIX:=ce-fleet-sandbox}"
 # get the current resource group name
 resource_group_name=$(ibmcloud target -o JSON | jq -r '.resource_group.name')
 region=$(ibmcloud target -o JSON | jq -r '.region.name')
-cos_instance=${resource_group_name/--rg/}--cos
+cos_instance=${NAME_PREFIX}--cos
 
 echo "switching to COS instance $cos_instance"
 


### PR DESCRIPTION
This PR enables to run our fleet scripts in environments in which the user only has permissions in a specific pre-defined resource group. So far the scripts assumes that a new resource group is created along with the initial setup.

This PR allows to setup fleet environments as follows:
```
RESOURCE_GROUP=<some-rg-name> REGION=eu-de ./serverless-fleets/init-fleet-sandbox
```